### PR TITLE
Handle trailing error added by formatter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ function formatStyles(styles: string) {
     .replace("}", "")
     .split(",")
     .map(style => style.trim())
+    .filter(style => !!style)
     .map(addIdentationToIndividualStyle)
     .join(",\n");
 


### PR DESCRIPTION
I'm using prettier and it always adds trailing comma at the end of styles
I wrote validation to filter out the trailing comma after split